### PR TITLE
tests: move remaining tests to pytest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Improve tests.
 
 
 0.3 (2019-09-07)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+test:
+	pytest -vv --pdb --pdbcls=IPython.terminal.debugger:Pdb
+
+release:
+	fullrelease
+
+update:
+	pip install --upgrade -e .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ dev =
     black
     doc8
     flake8
+    ipython
     pytest
     zest.releaser[recommended]
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -18,23 +18,6 @@ class AnalysisError(Exception):
 
 class Analyzer(object):
     """Used to analyze TWDA, find affinity between cards and build decks.
-
-    Usage:
-    >>> # Create analyzer and refresh - optionally, reference cards can be given
-    >>> A = Analyzer()
-    >>> A.refresh()
-    >>> # Get the number of decks playing any given card
-    >>> A.played["Octopod"]
-    5
-    >>> # Get affinity for cards given as argument to refresh
-    >>> # The score is the number of TWD playing these cards together
-    >>> A.refresh("Octopod")
-    >>> A.affinity["Octopod"].most_common()[0]
-    ('Immortal Grapple', 5)
-    >>> # Use similarity of 1 to get all decks matching the full card list
-    >>> A.refresh("Octopod", "Ivory Bow", similarity=1)
-    >>> len(A.examples)
-    1
     """
 
     def __init__(self):
@@ -77,11 +60,19 @@ class Analyzer(object):
         return self.deck
 
     def refresh(self, *args, similarity=0.6, condition=None):
-        """Sample TWDA.
+        """Sample TWDA. This is the core method of the Analyzer.
 
-        Fetch `self.examples` from TWDA.
+        Fetch `self.examples` decks from TWDA.
+
         If card names are given as args, only examples containing similar cards
-        are selected as examples. `self.affinity` is computed for given cards.
+        are selected as examples and `self.affinity` is computed for all given cards.
+
+        Similarity is used to select example decks from TWDA.
+        A default similarity of 60% (6 out of 10 cards matching) is used to select
+        example decks for the `build_deck` feature.
+        When trying to find decks containing specific cards,
+        similarity=1 can be used to have a 100% match, meaning all cards given as
+        args must be present in the deck for it to be selected as an example.
 
         If `self.deck` has been created (e.g. by calling `build_deck`),
         `self.average` of number played is computed for each example card

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,16 @@
+from src import analyzer
+from src import twda
+from src import vtes
+
+
+def test_base():
+    vtes.VTES.load_from_vekn()
+    # speed up the tests: parse the first 100 decks only to avoid useless 25 seconds.
+    twda.TWDA.load_from_vekn(limit=100)
+    A = analyzer.Analyzer()
+    A.refresh()
+    assert A.played["Stavros"] == 1
+    A.refresh("Stavros")
+    assert sorted(A.affinity["Stavros"].most_common())[0] == ("Adana de Sforza", 1)
+    A.refresh("Stavros", "Adana de Sforza", similarity=1)
+    assert len(A.examples) == 1

--- a/tests/test_vtes.py
+++ b/tests/test_vtes.py
@@ -1,0 +1,47 @@
+from src import vtes
+
+
+def test_init():
+    vtes.VTES.load_from_vekn()
+    vtes.VTES.configure()
+    assert sorted(vtes.VTES.trait_choices("Discipline")) == [
+        "Abombwe",
+        "Animalism",
+        "Auspex",
+        "Celerity",
+        "Chimerstry",
+        "Combo",
+        "Daimoinon",
+        "Defense",
+        "Dementation",
+        "Dominate",
+        "Flight",
+        "Fortitude",
+        "Innocence",
+        "Judgment",
+        "Maleficia",
+        "Martyrdom",
+        "Melpominee",
+        "Mytherceria",
+        "Necromancy",
+        "Obeah",
+        "Obfuscate",
+        "Obtenebration",
+        "Potence",
+        "Presence",
+        "Protean",
+        "Quietus",
+        "Redemption",
+        "Sanguinus",
+        "Serpentis",
+        "Spiritus",
+        "Striga",
+        "Temporis",
+        "Thanatosis",
+        "Thaumaturgy",
+        "Valeren",
+        "Vengeance",
+        "Vicissitude",
+        "Visceratika",
+        "Vision",
+    ]


### PR DESCRIPTION
- Move "load from VEKN" requests code out of cli.py
- Remove the "test" command
- Limit the number of decks parsed out of TWDA for faster tests