### PR TITLE
remove darkling trickery ruling

### DIFF
--- a/rulings/cards-rulings.yaml
+++ b/rulings/cards-rulings.yaml
@@ -573,7 +573,6 @@
   - The card is still considered played. The same reaction or modifier cannot be played again by the same minion. Another Aim card can not be played once one has been canceled, nor any other card which text prohibits to be played more than once. [LSJ 19980212] [ANK 20190104]
   - Can only cancel minion cards played from the hand in the normal fashion (eg. not weapons played via {Disguised Weapon} or allies from {Piper}). [RTR 20001020]
 100496|Darkling Trickery:
-  - "[MYT] Damage is environmental. [RTR 19970630] [LSJ19971028]"
   - '[MYT] Damage is inflicted even against a dodge. A "strike: combat ends" ends combat before damage is applied, as will a combattant going to torpor during first strike. [RTR 19941109] [TOM 19951216] [PIB 20140324] [ANK 20200422]'
 100499|Dartmoor, England:
   - May be put on any minion if the controller changes. If the new controller has no minions, it is burned. [RTR 19960112]


### PR DESCRIPTION
Environmental type is already stated in card text now.